### PR TITLE
Installation instruction should list ext.js dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Install `Connect`:
 Install `Express.js`:
     npm install express
 
+Install `Ext.js`:
+    npm install ext
+
 Compile the daemon add-on if you plan on letting the server daemonize itself:
     cd server/libs/daemon
     node-waf configure build


### PR DESCRIPTION
Hi,

After installation and trying to run the server according to the README instructions, I had the following error:

```
aminche:~/AjaxIM# node server/app.js 

node.js:275
    throw new Error("Cannot find module '" + request + "'");
      ^
Error: Cannot find module 'ext'
at loadModule (node.js:275:15)
at require (node.js:411:14)
at Object.<anonymous> (/root/AjaxIM/server/app.js:6:22)
at Module._compile (node.js:461:23)
at Module._loadScriptSync (node.js:468:10)
at Module.loadSync (node.js:338:12)
at Object.runMain (node.js:521:24)
at node.js:751:10
```

I believe the attached pull request fix this issue.
