### PR TITLE
Added missing argument to utils.uid()

### DIFF
--- a/server/dev/app.js
+++ b/server/dev/app.js
@@ -9,7 +9,7 @@ module.exports = function(app) {
 
     app.get('/cookie', function(req, res) {
         res.send('cookie set', {
-            'Set-Cookie': utils.serializeCookie('sessionid', utils.uid(),
+            'Set-Cookie': utils.serializeCookie('sessionid', utils.uid(24),
                                                 {path: '/'})
         });
     });


### PR DESCRIPTION
Ran into an issue getting the server to run in development mode. In app.js I found the call to utils.uid() was missing an argument to specify the length of the uid. I set this to 24.
