### PR TITLE
Change client example to support urls with a specified port

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -16,7 +16,9 @@ $(function(){
   }
   var u = window.location.href.split("/");
   var p = 8000; // Node.js port
-  u = u[0]+"//"+u[2]+":"+p;
+  u = u[0] + "//" + u[2];
+  u = u.split(':');
+  u = u[0] + ':' + u[1] + ':' + p;
   var im = AjaxIM.init({pollServer: u, theme: "themes/default"});
 });
 </script>


### PR DESCRIPTION
I noticed that when you were running the client with a specified port (e.g.: localhost:8080) the url was being set to localhost:8080:8000. This is a simple fix that will support both unspecified and specified port on URL location.
